### PR TITLE
Tweaks to diversity correction

### DIFF
--- a/cxt/utils.py
+++ b/cxt/utils.py
@@ -373,4 +373,42 @@ def diversity_bias_correction(
     return corrected if not return_intercept else (corrected, intercept)
 
 
+def diversity_bias_correction_by_rep(
+    tree_sequence: tskit.TreeSequence,
+    mutation_rate: float,
+    predictions: np.ndarray,
+    pivot_pairs: np.ndarray,
+    zero_offset: float = 0.0,
+    return_intercept: bool = False,
+) -> (np.ndarray, np.ndarray):
+    """
+    Correct the predicted TMRCAs such that expected diversity matches
+    observed diversity, for a given mutation rate. 
+
+    The input predictions are assumed to have dimensions 
+    `(replicates, pairs, windows)`.
+
+    The correction is undefined for pairs with zero observed diversity.
+    In this case, an offset equal to the minimum nonzero diversity in the sample 
+    is added (if `zero_offset` is zero, default).
+    """
+    assert predictions.ndim == 3
+    assert pivot_pairs.ndim == 2
+    assert pivot_pairs.shape[0] == predictions.shape[1]
+    assert pivot_pairs.shape[1] == 2
+    obs_div = tree_sequence.trim().diversity(sample_sets=pivot_pairs)
+    obs_div[obs_div == 0] = obs_div[obs_div > 0].min() if zero_offset == 0 \
+        else zero_offset / tree_sequence.trim().sequence_length
+    corrected = []
+    for rep in predictions:
+        fit_div = 2 * np.exp(rep).mean(axis=-1) * mutation_rate
+        assert np.all(obs_div > 0)
+        assert np.all(fit_div > 0)
+        corrected.append(
+            rep + (np.log(obs_div) - np.log(fit_div))[:, np.newaxis]
+        )
+    corrected = np.stack(corrected)
+    intercept = np.log(obs_div / mutation_rate / 2)[None, :, None]
+    return corrected if not return_intercept else (corrected, intercept)
+
 

--- a/experiments/model-calibration/bias-and-rmse-test.py
+++ b/experiments/model-calibration/bias-and-rmse-test.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from cxt.inference import translate_from_multi_ts_multi_gpu
 from cxt.config import BroadModelConfig 
 from cxt.utils import diversity_bias_correction
+from cxt.utils import diversity_bias_correction_by_rep
 
 from model_rescaling import scale_model, scale_growth_rates
 
@@ -21,6 +22,7 @@ if __name__ == "__main__":
     parser.add_argument("--growth-rate-scale", type=float, help="Scale exponential growth rates by this", default=1.0)
     parser.add_argument("--coal-unit-scale", type=float, help="Scale coalescent units by this", default=1.0)
     parser.add_argument("--overwrite-cache", action="store_true", help="Recalculate cached results")
+    parser.add_argument("--correct-by-rep", action="store_true", help="Do correction rep by rep rather than on rep average")
     parser.add_argument("--outpath", type=str, help="Output plot", default="correction-bias-and-rmse.png")
     args = parser.parse_args()
     
@@ -66,8 +68,10 @@ if __name__ == "__main__":
         for i in range(ts.num_samples) 
         for j in range(i + 1, ts.num_samples)
     ])
+    correction = diversity_bias_correction_by_rep if args.correct_by_rep else \
+        diversity_bias_correction
     corrected_yhats_pool, corrected_baselines_pool = \
-        diversity_bias_correction(
+        correction(
             tree_sequence=ts,
             mutation_rate=contig.mutation_rate,
             predictions=yhats,


### PR DESCRIPTION
- Correction now takes multiple replicates; calculates predicted diversity from average of these replicates (in log space); returns corrected replicates
- Pairs with zero observed diversity have an offset added, that by default is the min nonzero diversity in the sample